### PR TITLE
Add bower.json for installation via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,5 @@
+{
+        "name": "sawkit-client",
+        "version": "1.0",
+        "main": "$ws.js"
+}


### PR DESCRIPTION
This allows bower users to manage sawkit-client along with other dependencies. It may also mean tagging releases on the project, but that is never a bad idea ;)
